### PR TITLE
fix: Change field name from content to description on form

### DIFF
--- a/frontend/src/domains/notice/components/notice-form.tsx
+++ b/frontend/src/domains/notice/components/notice-form.tsx
@@ -86,7 +86,7 @@ export const NoticeForm: React.FC<Props> = ({
         sx={{ marginTop: '20px' }}
       />
       <TextField
-        {...register('content')}
+        {...register('description')}
         error={Boolean(errors.description)}
         helperText={errors.description?.message}
         type='text'

--- a/frontend/src/domains/notice/pages/add-notice-page.tsx
+++ b/frontend/src/domains/notice/pages/add-notice-page.tsx
@@ -16,7 +16,7 @@ import { NoticeForm } from '../components';
 
 const initialState: NoticeFormProps = {
   title: '',
-  content: '',
+  description: '',
   status: 0,
   recipientType: 'EV',
   recipientRole: 0,


### PR DESCRIPTION
- Change all references of the field content to description to allow the Add Notice form to operate correctly.

![testDescription](https://github.com/user-attachments/assets/340555d5-af73-4230-afaf-25dddf8fb619)
![testDescriptionUpdated](https://github.com/user-attachments/assets/3e48185c-565d-4b6a-aed9-c687fdfbc8cb)
